### PR TITLE
Changed the label from OriginalMD5Checksum to Original file name in t…

### DIFF
--- a/lib/features/document_details/view/widgets/document_meta_data_widget.dart
+++ b/lib/features/document_details/view/widgets/document_meta_data_widget.dart
@@ -4,7 +4,6 @@ import 'package:intl/intl.dart';
 import 'package:paperless_api/paperless_api.dart';
 import 'package:paperless_mobile/core/database/tables/local_user_account.dart';
 import 'package:paperless_mobile/core/extensions/flutter_extensions.dart';
-import 'package:paperless_mobile/core/repository/user_repository.dart';
 import 'package:paperless_mobile/features/document_details/view/widgets/archive_serial_number_field.dart';
 import 'package:paperless_mobile/features/document_details/view/widgets/details_item.dart';
 import 'package:paperless_mobile/generated/l10n/app_localizations.dart';
@@ -52,7 +51,7 @@ class DocumentMetaDataWidget extends StatelessWidget {
           DetailsItem.text(
             document.originalFileName!,
             context: context,
-            label: S.of(context)!.originalMD5Checksum,
+            label: S.of(context)!.originalFileName,
           ).paddedOnly(bottom: itemSpacing),
         DetailsItem.text(
           metaData.originalChecksum,

--- a/lib/features/document_details/view/widgets/document_overview_widget.dart
+++ b/lib/features/document_details/view/widgets/document_overview_widget.dart
@@ -6,7 +6,6 @@ import 'package:paperless_mobile/core/database/tables/local_user_account.dart';
 import 'package:paperless_mobile/core/repository/label_repository.dart';
 import 'package:paperless_mobile/core/widgets/highlighted_text.dart';
 import 'package:paperless_mobile/core/extensions/flutter_extensions.dart';
-import 'package:paperless_mobile/core/widgets/shimmer_placeholder.dart';
 import 'package:paperless_mobile/features/document_details/view/widgets/details_item.dart';
 import 'package:paperless_mobile/features/labels/tags/view/widgets/tags_widget.dart';
 import 'package:paperless_mobile/features/labels/view/widgets/label_text.dart';

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -161,6 +161,8 @@
   "@filterDocuments": {
     "description": "Title of the document filter"
   },
+  "originalFileName": "Original File Name",
+  "@originalFileName": {},
   "originalMD5Checksum": "Original MD5-Checksum",
   "@originalMD5Checksum": {},
   "mediaFilename": "Media Filename",


### PR DESCRIPTION
From Author

Fix to the github issue: https://github.com/astubenbord/paperless-mobile/issues/462. Mainly changed the label from the original MD5 File to "Original file name". Created an entry in the intl_en.arb file. The string needs to be translated into different languages.